### PR TITLE
Add option to not print the surrounding === lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ Korean and Japanese(which takes two spaces by character in terminal) will looks 
 Usage
 
 $ ~/sequence-diagram-cli > seqdia 'YOUR_SEQUENCE_DIAGRAM_FILE'
-$ ~/sequence-diagram-cli > seqdia 'YOUR_SEQUENCE_DIAGRAM_FILE' prefix='// ' suffix='|' al
+$ ~/sequence-diagram-cli > seqdia 'YOUR_SEQUENCE_DIAGRAM_FILE' prefix='// ' suffix='|' al raw
 
 v1.1
 // with ' al ' option will draw sequence diagram in pure character not utf-8.
+
+// with ' raw ' the surrounding lines will not be printed
 
 //example
 $ ~/sequence-diagram-cli > seqdia tests/test.txt

--- a/main.c
+++ b/main.c
@@ -47,6 +47,7 @@ int main(int argc, char *argv[])
 
     prefix = NULL;
     suffix = NULL;
+    printRaw = false;
 
     bool is_text = false;
 
@@ -75,6 +76,10 @@ int main(int argc, char *argv[])
         else if (!strcmp(argv[i], "al"))
         {
             is_text = true;
+        }
+        else if (!strcmp(argv[i], "raw"))
+        {
+            printRaw = true;
         }
         else if (!strncmp(argv[i], "prefix=", 7))
         {

--- a/main.h
+++ b/main.h
@@ -6,5 +6,6 @@
 int SHOW_LOG;
 char *prefix;
 char *suffix;
+bool printRaw;
 
 #include "renderer.h"

--- a/renderer.c
+++ b/renderer.c
@@ -663,12 +663,16 @@ void render()
         l += strlen(suffix);
 
     char a[l];
-    memset(a, '=', l);
-    a[l] = '\0';
-    printf(KGRN"%s\n"RESET, a);
+    if (!printRaw) {
+        memset(a, '=', l);
+        a[l] = '\0';
+        printf(KGRN"%s\n"RESET, a);
+    }
 
     print_header(new_area);
     print_body(new_area);
 
-    printf(KGRN"%s\n"RESET, a);
+    if (!printRaw) {
+        printf(KGRN"%s\n"RESET, a);
+    }
 }

--- a/renderer.h
+++ b/renderer.h
@@ -7,6 +7,7 @@
 
 extern char *prefix;
 extern char *suffix;
+extern bool printRaw;
 
 #define GET_LINE_M(from, to) \
     (to - from) / 2 + from


### PR DESCRIPTION
The lines surrounding the generated diagrams (`========`) are inconvenient when `seqdia` is used in scripts (or e.g. [`slides`](https://github.com/maaslalani/slides)) to generate diagrams on the fly, especially because they are colour coded. 

This PR introduces the `raw` option which when specified, makes the renderer not print those lines.